### PR TITLE
Update list of removed files

### DIFF
--- a/lib/inter_model/inter_model.py
+++ b/lib/inter_model/inter_model.py
@@ -134,7 +134,7 @@ def check_incorrectly_split_genes(gff, gff_file, fasta_file, logger):
         gff.add_line_error(pair['target'], {'message': '{0:s} between {1:s} and {2:s}'.format(ERROR_INFO[eCode], pair['source']['attributes']['ID'], pair['target']['attributes']['ID']), 'error_type': 'INTER_MODEL', 'eCode': eCode})
 
     logger.info('Removing unnecessary files...')
-    subprocess.Popen(['rm', 'tmp_cds.fa.nhr', 'tmp_cds.fa.nin', 'tmp_cds.fa.nsq', 'blastn.out', 'GeneModelwithMultipleIsoforms.txt','ck_wrong_split.report']) #debug 07082015
+    subprocess.Popen(['rm', 'tmp_cds.fa', 'tmp_cds.fa.nhr', 'tmp_cds.fa.nin', 'tmp_cds.fa.nsq', 'blastn.out', 'GeneModelwithMultipleIsoforms.txt','ck_wrong_split.report']) #debug 07082015
 
     if len(eSet):
         return eSet


### PR DESCRIPTION
Just found the file `tmp_cds.fa` isn't be removed. BTW, I think use `os.remove` will be better here, because `rm` is not available to Windows system. However, we haven't support windows yet, so maybe it's not a big deal.