### PR TITLE
fix to install on macOS Mojave + anaconda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ from codecs import open
 from os import path, remove, mkdir
 import shutil
 import tarfile
-from urllib.request import urlretrieve
+try:
+	from urllib.request import urlretrieve
+except ImportError:
+	from urllib import urlretrieve
 
 import platform
 import sys


### PR DESCRIPTION
Hi !
I was not able to install the tool on my computer due to problem to import urlretrieve.
I added a fix backward compatible to try to import it differently.

Best,

/Jacques
